### PR TITLE
Feat/encoding detection

### DIFF
--- a/src/utils/encoding/constants.ts
+++ b/src/utils/encoding/constants.ts
@@ -1,0 +1,5 @@
+export const REGEX_TESTS: Record<string, RegExp> = {
+  NUMERIC: /^\d*$/,
+  ALPHA_NUMERIC: /^[A-Z\d $%*+\-./,:]*$/,
+};
+

--- a/src/utils/encoding/constants.ts
+++ b/src/utils/encoding/constants.ts
@@ -3,3 +3,6 @@ export const REGEX_TESTS: Record<string, RegExp> = {
   ALPHA_NUMERIC: /^[A-Z\d $%*+\-./,:]*$/,
 };
 
+export const CHARSET: Record<string, string> = {
+  ALPHA_NUMERIC: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:',
+};

--- a/src/utils/encoding/detectors.test.ts
+++ b/src/utils/encoding/detectors.test.ts
@@ -1,0 +1,58 @@
+import { CHARSET } from './constants';
+import detectors from './detectors';
+
+describe('Encoding detectors', () => {
+  const numericTestValues = [
+    '1',
+    '23',
+    '123456789',
+    '345345',
+    '253453535',
+    ...[new Array(10)].map(() => Math.round(Math.random() * 10).toString()),
+  ];
+
+  const alphaNumericTestValues = [
+    'A1',
+    'ABC123',
+    'A1B2C3.',
+    '%$',
+    '$%*+-./:',
+    CHARSET.ALPHA_NUMERIC,
+  ];
+
+  const byteTestValues = ['abc123ABC', 'ABC_123', '123;ABC'];
+
+  describe('NUMERICS detector', () => {
+    it.each(numericTestValues)('accepts NUMERIC input', (testString) => {
+      expect(detectors.isNumeric(testString)).toBeTruthy();
+    });
+
+    it.each(alphaNumericTestValues)(
+      'rejects ALPHA_NUMERIC input',
+      (testString) => {
+        expect(detectors.isNumeric(testString)).toBeFalsy();
+      },
+    );
+
+    it.each(byteTestValues)('rejects BYTE input', (testString) => {
+      expect(detectors.isNumeric(testString)).toBeFalsy();
+    });
+  });
+
+  describe('ALPHA_NUMERICS detector', () => {
+    it.each(numericTestValues)('accepts NUMERIC input', (testString) => {
+      expect(detectors.isAlphaNumeric(testString)).toBeTruthy();
+    });
+
+    it.each(alphaNumericTestValues)(
+      'accepts ALPHA_NUMERIC input',
+      (testString) => {
+        expect(detectors.isAlphaNumeric(testString)).toBeTruthy();
+      },
+    );
+
+    it.each(byteTestValues)('rejects BYTE input', (testString) => {
+      expect(detectors.isAlphaNumeric(testString)).toBeFalsy();
+    });
+  });
+});

--- a/src/utils/encoding/detectors.ts
+++ b/src/utils/encoding/detectors.ts
@@ -1,0 +1,11 @@
+import { REGEX_TESTS } from './constants';
+
+const isNumeric = (value: string) => {
+  return value && REGEX_TESTS.NUMERIC.test(value);
+};
+
+const isAlphaNumeric = (value: string) => {
+  return value && REGEX_TESTS.ALPHA_NUMERIC.test(value);
+};
+
+export default { isNumeric, isAlphaNumeric };

--- a/src/utils/encoding/index.ts
+++ b/src/utils/encoding/index.ts
@@ -1,0 +1,1 @@
+export { default as detectors } from './detectors';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './encoding';


### PR DESCRIPTION
Adds helper functions to detect `numeric` and `alpha-numeric` strings in order to select correct bit encoding later.
Includes testing for both methods.